### PR TITLE
Improve CI Workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,24 +41,6 @@ jobs:
           name: Build Source
           command: make build
 
-  check_formatting:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: /
-      - run:
-          name: Check Formatting
-          command: test -z $(go fmt ./...)
-
-  vet_source:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: /
-      - run:
-          name: Vet Source
-          command: make vet
-
   lint_source:
     <<: *defaults
     steps:
@@ -69,7 +51,7 @@ jobs:
          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
      - run:
          name: Check for Lint
-         command: golangci-lint run ./...
+         command: golangci-lint run
 
   lint_markdown:
     docker:
@@ -91,12 +73,6 @@ workflows:
     jobs:
       - get_source
       - build_source:
-          requires:
-            - get_source
-      - check_formatting:
-          requires:
-            - get_source
-      - vet_source:
           requires:
             - get_source
       - lint_source:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,20 @@ defaults: &defaults
     - image: golang:1.12
 
 jobs:
-  get_source:
+  lint_markdown:
+    <<: *defaults
+    docker:
+      - image: node:11-slim
+    steps:
+      - checkout
+      - run:
+          name: Install markdownlint
+          command: npm install -g markdownlint-cli
+      - run:
+          name: Check for Lint
+          command: markdownlint .
+
+  cache_go_mod:
     <<: *defaults
     steps:
       - checkout
@@ -15,28 +28,19 @@ jobs:
             - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Populate Go Mod Cache
-          command: |
-            if [ ! -d /go/pkg/mod ]; then
-              go mod download
-            fi
+          command: go mod download
       - save_cache:
           key: go-mod-{{ checksum "go.sum" }}
           paths:
-            - /go/pkg/mod
-      - run:
-          name: Go Mod Verify
-          command: go mod verify
-      - persist_to_workspace:
-          root: /
-          paths:
-            - go/pkg/mod
-            - src
+            - '/go/pkg/mod'
 
   build_source:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: /
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Build Source
           command: make build
@@ -44,41 +48,27 @@ jobs:
   lint_source:
     <<: *defaults
     steps:
-     - attach_workspace:
-         at: /
-     - run:
-         name: Install golangci-lint
-         command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
-     - run:
-         name: Check for Lint
-         command: golangci-lint run
-
-  lint_markdown:
-    <<: *defaults
-    docker:
-      - image: node:11-slim
-    steps:
-      - attach_workspace:
-          at: /
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
       - run:
-          name: Install markdownlint
-          command: npm install -g markdownlint-cli
+          name: Install golangci-lint
+          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
       - run:
           name: Check for Lint
-          command: markdownlint .
+          command: golangci-lint run
 
 workflows:
   version: 2
-  
+
   build_and_test:
     jobs:
-      - get_source
+      - lint_markdown
+      - cache_go_mod
       - build_source:
           requires:
-            - get_source
+            - cache_go_mod
       - lint_source:
           requires:
-            - get_source
-      - lint_markdown:
-          requires:
-            - get_source
+            - cache_go_mod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
          at: /
      - run:
          name: Install golangci-lint
-         command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+         command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
      - run:
          name: Check for Lint
          command: golangci-lint run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+
+orbs:
+  codecov: codecov/codecov@1.0.4
 
 defaults: &defaults
   working_directory: /src
@@ -59,6 +62,19 @@ jobs:
           name: Check for Lint
           command: golangci-lint run
 
+  unit_test:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
+      - run:
+          name: Run Tests
+          command: go test -coverprofile cover.out -race ./...
+      - codecov/upload:
+          file: cover.out
+
 workflows:
   version: 2
 
@@ -70,5 +86,8 @@ workflows:
           requires:
             - cache_go_mod
       - lint_source:
+          requires:
+            - cache_go_mod
+      - unit_test:
           requires:
             - cache_go_mod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,17 +54,18 @@ jobs:
          command: golangci-lint run
 
   lint_markdown:
+    <<: *defaults
     docker:
-      - image: circleci/ruby:2.4.1-node
+      - image: node:11-slim
     steps:
       - attach_workspace:
-          at: .
+          at: /
       - run:
           name: Install markdownlint
-          command: sudo npm install -g markdownlint-cli
+          command: npm install -g markdownlint-cli
       - run:
           name: Check for Lint
-          command: markdownlint --config src/.markdownlint.json src/
+          command: markdownlint .
 
 workflows:
   version: 2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+linters:
+  enable-all: true
+  disable:
+    - gochecknoglobals
+    - gocritic
+    - lll
+    - maligned
+    - stylecheck
+    - unparam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ linters:
   enable-all: true
   disable:
     - gochecknoglobals
+    - gochecknoinits
     - gocritic
     - lll
     - maligned

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.lintTool": "golangci-lint"
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # nomad-driver-singularity
 
+[![Code Coverage](https://codecov.io/gh/sylabs/nomad-driver-singularity/branch/master/graph/badge.svg)](https://codecov.io/gh/sylabs/nomad-driver-singularity)
+
 [Hashicorp Nomad](https://www.nomadproject.io/) driver plugin using
 [Singularity containers](https://github.com/sylabs/singularity) to execute tasks.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # nomad-driver-singularity
 
 [![Code Coverage](https://codecov.io/gh/sylabs/nomad-driver-singularity/branch/master/graph/badge.svg)](https://codecov.io/gh/sylabs/nomad-driver-singularity)
+[![Go Report Card](https://goreportcard.com/badge/github.com/sylabs/nomad-driver-singularity)](https://goreportcard.com/report/github.com/sylabs/nomad-driver-singularity)
 
 [Hashicorp Nomad](https://www.nomadproject.io/) driver plugin using
 [Singularity containers](https://github.com/sylabs/singularity) to execute tasks.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # nomad-driver-singularity
 
 [![GoDoc](https://godoc.org/github.com/sylabs/nomad-driver-singularity?status.svg)](https://godoc.org/github.com/sylabs/nomad-driver-singularity)
+[![Build Status](https://circleci.com/gh/sylabs/nomad-driver-singularity.svg?style=shield)](https://circleci.com/gh/sylabs/workflows/nomad-driver-singularity)
 [![Code Coverage](https://codecov.io/gh/sylabs/nomad-driver-singularity/branch/master/graph/badge.svg)](https://codecov.io/gh/sylabs/nomad-driver-singularity)
 [![Go Report Card](https://goreportcard.com/badge/github.com/sylabs/nomad-driver-singularity)](https://goreportcard.com/report/github.com/sylabs/nomad-driver-singularity)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # nomad-driver-singularity
 
+[![GoDoc](https://godoc.org/github.com/sylabs/nomad-driver-singularity?status.svg)](https://godoc.org/github.com/sylabs/nomad-driver-singularity)
 [![Code Coverage](https://codecov.io/gh/sylabs/nomad-driver-singularity/branch/master/graph/badge.svg)](https://codecov.io/gh/sylabs/nomad-driver-singularity)
 [![Go Report Card](https://goreportcard.com/badge/github.com/sylabs/nomad-driver-singularity)](https://goreportcard.com/report/github.com/sylabs/nomad-driver-singularity)
 


### PR DESCRIPTION
Use `checkout` to retrieve source, `restore_cache` to fetch cached Go modules. This follows the recommendations on the [CircleCI blog](https://circleci.com/blog/deep-diving-into-circleci-workspaces/).

Fold the `check_formatting` and `vet_source` jobs into the `lint_source` job. Upgrade `golanglint-ci` to version 1.16, and add a `golangci-lint` config to explicitly opt out of failing linters. Add project-level VS Code setting to use `golangci-lint` for linting.

Use `node:11-slim` (148MB) instead of `circleci/ruby:2.4.1-node` (960MB) for `lint_markdown` job.

Add `unit_test` job, and report code coverage via the [Codecov Orb](https://circleci.com/orbs/registry/orb/codecov/codecov).

Add GoDoc, CircleCI, Codecov and Go Report Card badges.

Closes #19 